### PR TITLE
updating readme with ssh info for kvstore and using sudo to run docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ docker-machine create --driver amazonec2 kvstore
 ```
 eval $(docker-machine env kvstore)
 export KV_IP=$(docker-machine ip kvstore)
-docker run -d -p 8500:8500 -h consul --restart=always progrium/consul -server -bootstrap
+docker-machine ssh kvstore
+sudo docker run -d -p 8500:8500 -h consul --restart=always progrium/consul -server -bootstrap
 ```
 
 - Create an instance for running the Swarm master:


### PR DESCRIPTION
Small update to the README to show how to SSH into the machine to startup up the consul server and that you need to run the docker command with sudo.
